### PR TITLE
setting custom object mapper is now optional

### DIFF
--- a/src/main/java/com/simplaex/clients/druid/DruidClientConfig.java
+++ b/src/main/java/com/simplaex/clients/druid/DruidClientConfig.java
@@ -1,5 +1,7 @@
 package com.simplaex.clients.druid;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
 import lombok.*;
 
 import javax.annotation.Nonnegative;
@@ -15,11 +17,21 @@ public class DruidClientConfig {
   @Getter
   private final String host;
   private final Integer port;
+  private final ObjectMapper objectMapper;
 
   private final Supplier<ExecutorService> executorServiceFactory;
   private final ExecutorService executorService;
 
   private final DruidClient.EventEmitter eventEmitter;
+
+
+  public ObjectMapper getObjectMapper() {
+    if (objectMapper == null) {
+      return new DefaultObjectMapper();
+    } else {
+      return objectMapper;
+    }
+  }
 
   @Nonnull
   public ExecutorService getExecutorService() {

--- a/src/main/java/com/simplaex/clients/druid/DruidClientImpl.java
+++ b/src/main/java/com/simplaex/clients/druid/DruidClientImpl.java
@@ -68,7 +68,8 @@ public final class DruidClientImpl implements DruidClient {
     final ServiceEmitter serviceEmitter = createServiceEmitter(config.getHost(), config.getEventEmitter());
     this.queryManager = new QueryManager();
     this.executorService = config.getExecutorService();
-    this.druidClient = createDruidClient(config.getHost(), config.getPort(), queryManager, serviceEmitter, executorService);
+    this.druidClient = createDruidClient(config.getHost(), config.getPort(), queryManager, serviceEmitter, executorService,
+      config.getObjectMapper());
   }
 
   private static DirectDruidClient createDruidClient(
@@ -76,9 +77,9 @@ public final class DruidClientImpl implements DruidClient {
     final int port,
     final QueryWatcher queryWatcher,
     final ServiceEmitter serviceEmitter,
-    final ExecutorService executorService
+    final ExecutorService executorService,
+    final ObjectMapper objectMapper
   ) {
-    final ObjectMapper objectMapper = new DefaultObjectMapper();
     final String host = String.format("%s:%d", hostname, port);
     return new DirectDruidClient(
       createQueryToolChestWarehouse(objectMapper, serviceEmitter, queryWatcher, executorService),


### PR DESCRIPTION
The DefaultObjectMapper registers certain modules shipped with Druid.
However, custom extensions (e.g. AggregatorFactory)  are not registered.
This allows registering custom types by exposing the ObjectMapper.